### PR TITLE
Added ability to add/change options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,23 @@ bind9_forwarders:
 bind9_allow_query:
   - "any"
 
+# Extra options are put into the "options" section of named.conf.options
+bind9_extra_options:
+  - dnssec-validation auto;
+
+# if bind9_logging is defined, this will be put in the "logging" section
+# of named.conf.options
+#bind9_logging:
+#  - 'channel query_log {'
+#  - '  file "/var/log/named/query.log" versions 3 size 10M;'
+#  - '  severity info;'
+#  - '  print-time yes;'
+#  - '};'
+#  - 'category queries {'
+#  - '  query_log;'
+#  - '};'
+
+
 bind9_statistics: true # enable statistics-channels on port 127.0.0.1:8053 use bind_exporter to scrape metrics
 
 bind9_zones:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,15 +16,15 @@ bind9_extra_options:
 
 # if bind9_logging is defined, this will be put in the "logging" section
 # of named.conf.options
-#bind9_logging:
-#  - 'channel query_log {'
-#  - '  file "/var/log/named/query.log" versions 3 size 10M;'
-#  - '  severity info;'
-#  - '  print-time yes;'
-#  - '};'
-#  - 'category queries {'
-#  - '  query_log;'
-#  - '};'
+# bind9_logging:
+#   - 'channel query_log {'
+#   - '  file "/var/log/named/query.log" versions 3 size 10M;'
+#   - '  severity info;'
+#   - '  print-time yes;'
+#   - '};'
+#   - 'category queries {'
+#   - '  query_log;'
+#   - '};'
 
 
 bind9_statistics: true # enable statistics-channels on port 127.0.0.1:8053 use bind_exporter to scrape metrics

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -23,6 +23,14 @@
   # and only slaves will have a master attribute
   notify: Restart bind9
 
+- name: "Ensure directory exists for log files"
+  ansible.builtin.file:
+    path: /var/log/named
+    state: directory
+    owner: bind
+    group: bind
+    mode: "0700"
+
 - name: "Generate named.conf.local"
   ansible.builtin.template:
     src: named.conf.local.j2

--- a/templates/named.conf.options.j2
+++ b/templates/named.conf.options.j2
@@ -11,7 +11,11 @@ options {
     };
 {% endif %}
 
-    dnssec-validation auto;
+{% if bind9_extra_options %}
+    {% for line in bind9_extra_options %}
+        {{ line }}
+    {% endfor %}
+{% endif %}
 {% if bind9_allow_query %}
     allow-query     {
         {% for network in bind9_allow_query %}
@@ -26,5 +30,13 @@ options {
 {% if bind9_statistics %}
 statistics-channels {
     inet 127.0.0.1 port 8053 allow { 127.0.0.1; };
+};
+{% endif %}
+
+{% if bind9_logging %}
+logging {
+  {% for line in bind9_logging %}
+  {{ line }}
+  {% endfor %}
 };
 {% endif %}


### PR DESCRIPTION
This change does three things:

1. enables logging queries to a file
2. allows additional options to be specified
3. doesn't force `dnssec-validation` to be set to `auto`

The logging is pretty self explanatory.

Allowing additional options should also be pretty straight forward. For example, setting `version` will prevent the disclosure of the exact version of bind that is being run ([docs](https://bind9.readthedocs.io/en/v9.16.22/reference.html#built-in-server-information-zones)). There are many other options that people might want and this enables them to set them without the role having to explicitly support each one.

The need for the ability to explicitly disable dnssec validation is due to this issue: https://access.redhat.com/solutions/5633621

I've tested all of these changes, as I need each of these features in my environment. Everything should be backward compatible so no existing Ansible variables should need changed.