### PR TITLE
Allow multiple ORGINs and remove hardcoded records

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,9 +39,15 @@ bind9_zones:
     allow_transfer:
       - "127.0.0.1"
     records:
+      - name: "{{ bind9_ns_name }}"
+        type: "A"
+        value: "{{ ansible_default_ipv4.address }}"
       - name: "@"
         type: "A"
         value: "127.0.0.1"
+      - name: "@"
+        type: "AAAA"
+        value: "::1"
   - name: "example.org"  # slave
     serial: "10" #  "{{ ansible_date_time.epoch }}"
     refresh: 3600

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,10 @@ bind9_zones:
       - name: "@"
         type: "AAAA"
         value: "::1"
+      - origin: "test.example.com"
+      - name: "test" # test.example.com
+        type: "A"
+        value: "127.0.0.1"
   - name: "example.org"  # slave
     serial: "10" #  "{{ ansible_date_time.epoch }}"
     refresh: 3600

--- a/templates/db.local.j2
+++ b/templates/db.local.j2
@@ -12,5 +12,9 @@ $TTL    604800
 @       IN      NS      {{ bind9_ns_name }}.{{ item.name }}.
 
 {% for record in item.records %}
+{% if "origin" in record %}
+{{ record.origin }}.
+{% else %}
 {{ record.name }}       IN      {{ record.type }}       {{ record.value }}
+{% endif %}
 {% endfor %}

--- a/templates/db.local.j2
+++ b/templates/db.local.j2
@@ -10,8 +10,6 @@ $TTL    604800
 ;
 
 @       IN      NS      {{ bind9_ns_name }}.{{ item.name }}.
-{{ bind9_ns_name }}       IN      A       {{ ansible_default_ipv4.address }}
-@       IN      AAAA    ::1
 
 {% for record in item.records %}
 {{ record.name }}       IN      {{ record.type }}       {{ record.value }}


### PR DESCRIPTION
Resolves #8 and #9

I was able to sort of keep backward compatibility by moving the records from the template into the default variables. I say "sort of" because those are always going to be overridden, which means users will still need to make changes.

The change is backward compatible, as it's a new key in the dictionary that no existing user would have.


This batch of changes should get me to the point where I can generate my existing config files with ansible. Very cool!