### PR TITLE
fix: corrected template and example

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,7 +49,7 @@ bind9_zones:
         type: "AAAA"
         value: "::1"
       - origin: "test.example.com"
-      - name: "test" # test.example.com
+      - name: "foo" # foo.test.example.com
         type: "A"
         value: "127.0.0.1"
   - name: "example.org"  # slave

--- a/templates/db.local.j2
+++ b/templates/db.local.j2
@@ -13,7 +13,7 @@ $TTL    604800
 
 {% for record in item.records %}
 {% if "origin" in record %}
-{{ record.origin }}.
+$ORIGIN {{ record.origin }}.
 {% else %}
 {{ record.name }}       IN      {{ record.type }}       {{ record.value }}
 {% endif %}


### PR DESCRIPTION
Well this is embarrassing. I forgot the keyword $ORIGIN! This merge requests fixes that and also updates the example to be both more clear and accurate in explaining the record which is created by the example yaml.

I've hot-patched my copy of your repo to test these changes and I can confirm that they work in my test environment.